### PR TITLE
Versioning using Git tag info

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,47 +4,9 @@ name: Build and upload to PyPI
 on: push
 
 jobs:
-  setup:
-    name: Check Release
-    runs-on: ubuntu-latest
-    outputs:
-      release: ${{ steps.autobump.outputs.release }}
-      search_replace: ${{ steps.autobump.outputs.search_replace }}
-      version_file: ${{ steps.autobump.outputs.version_file }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Release - Autobump version preparation
-        id: autobump
-        run: |
-          # from refs/tags/vX.Y.Z get X.Y.Z
-          RELEASE="${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}"
-          if [ "${RELEASE}" == "true" ]; then
-            echo "Release ${GITHUB_REF}"
-            VERSION=$(echo ${GITHUB_REF} | sed 's#.*/v##')
-            PLACEHOLDER="__version__ = '.*'"
-            SEARCH_REPLACE="s/${PLACEHOLDER}/__version__ = \'${VERSION}\'/g"
-            VERSION_FILE="vtool/__init__.py"
-
-            grep "${PLACEHOLDER}" "${VERSION_FILE}"
-          else
-            echo "Not Release"
-            SEARCH_REPLACE=""
-            VERSION_FILE=""
-          fi
-
-          echo "RELEASE=${RELEASE}"
-          echo "SEARCH_REPLACE=${SEARCH_REPLACE}"
-          echo "VERSION_FILE=${VERSION_FILE}"
-
-          echo "::set-output name=release::${RELEASE}"
-          echo "::set-output name=search_replace::${SEARCH_REPLACE}"
-          echo "::set-output name=version_file::${VERSION_FILE}"
-        shell: bash
 
   build_wheels:
     name: Build on ${{ matrix.os }}
-    needs: [setup]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -82,18 +44,6 @@ jobs:
         if: ${{ runner.os == 'macOS' && steps.caching.outputs.cache-hit != 'true' }}
         uses: WildbookOrg/wbia-pypkg-build/actions/macports@v1.0.0
 
-      - name: Release macOS - Autobump version for Mac
-        if: ${{ needs.setup.outputs.release == 'true' && runner.os == 'macOS' }}
-        run: |
-          sed -i "" "${{ needs.setup.outputs.search_replace }}" "${{ needs.setup.outputs.version_file }}"
-        shell: bash
-
-      - name: Release Linux - Autobump version for Linux
-        if: ${{ needs.setup.outputs.release == 'true' && runner.os == 'Linux' }}
-        run: |
-          sed -i "${{ needs.setup.outputs.search_replace }}" "${{ needs.setup.outputs.version_file }}"
-        shell: bash
-
       - name: Build wheel
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: wildme/manylinux:latest
@@ -110,27 +60,15 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build_sdist:
-    name: Build sdist
-    needs: [setup]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.7]
-
+    name: Build source distribution
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Release Linux - Autobump version for Linux
-        if: ${{ needs.setup.outputs.release == 'true' }}
-        run: |
-          sed -i "${{ needs.setup.outputs.search_replace }}" "${{ needs.setup.outputs.version_file }}"
-        shell: bash
+          python-version: '3.8'
 
       - name: Build sdist
         run: |
@@ -142,11 +80,10 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    name: Upload to PyPI
-    needs: [setup, build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: ${{ needs.setup.outputs.release == 'true' }}
-
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -157,3 +94,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}
+          # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            /opt/opencv
+            /opt
           # The key based on the file hash of the build script
           # i.e. changing OPENCV_VERSION within the script will invalidate the cache
           key: ${{ runner.os }}-build-opencv-${{ hashFiles('scripts/_install_opencv_*_on_macos.sh') }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          # This allows the setuptools_scm library to discover the tag version from git
+          fetch-depth: 0
 
       - uses: actions/setup-python@v2
         name: Install Python

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# setuptools_scm version discovery writes the version to <pkg>/_version.py
+**/_version.py
+
 # idk why this exists. probably jon's vimrc
 '
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,15 @@ string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
 include(${PROJECT_SOURCE_DIR}/CMake/vtool-utils.cmake)
 
-function(_pycmd outvar cmd)
+function(get_version outvar)
   execute_process(
-    COMMAND python -c "${cmd}"
+    COMMAND python setup.py --version
     RESULT_VARIABLE _exitcode
     OUTPUT_VARIABLE _output
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   if(NOT ${_exitcode} EQUAL 0)
     message(ERROR "Failed when running python code: \"\"\"
-${cmd}\"\"\"")
+python setup.py --version\"\"\"")
     message(FATAL_ERROR "Python command failed with error code: ${_exitcode}")
   endif()
   # Remove supurflous newlines (artifacts of print)
@@ -29,7 +29,7 @@ ${cmd}\"\"\"")
       "${_output}"
       PARENT_SCOPE)
 endfunction()
-_pycmd(VTOOL_VERSION "import setup; print(setup.version)")
+get_version(VTOOL_VERSION)
 
 message(STATUS "VTOOL_VERSION = ${VTOOL_VERSION}")
 

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,6 @@ NAME = 'wbia-vtool'
 
 
 MB_PYTHON_TAG = native_mb_python_tag()  # NOQA
-VERSION = version = parse_version('vtool/__init__.py')  # must be global for git tags
 
 AUTHORS = [
     'Avi Weinstock',
@@ -196,7 +195,6 @@ DESCRIPTION = 'Vtool - Image Tools for Wildbook IA'
 
 KWARGS = OrderedDict(
     name=NAME,
-    version=VERSION,
     author=', '.join(AUTHORS),
     author_email=AUTHOR_EMAIL,
     description=DESCRIPTION,
@@ -210,6 +208,16 @@ KWARGS = OrderedDict(
         'tests': parse_requirements('requirements/tests.txt'),
         'build': parse_requirements('requirements/build.txt'),
         'runtime': parse_requirements('requirements/runtime.txt'),
+    },
+    # --- VERSION ---
+    # The following settings retreive the version from git.
+    # See https://github.com/pypa/setuptools_scm/ for more information
+    setup_requires=['setuptools_scm'],
+    use_scm_version={
+        'write_to': 'vtool/_version.py',
+        'write_to_template': '__version__ = "{version}"',
+        'tag_regex': '^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$',
+        'local_scheme': 'dirty-tag',
     },
     # --- PACKAGES ---
     # The combination of packages and package_dir is how scikit-build will

--- a/vtool/__init__.py
+++ b/vtool/__init__.py
@@ -8,9 +8,8 @@ Autogenerate Command:
 # flake8: noqa
 from __future__ import absolute_import, division, print_function
 
-__version__ = '3.0.1'
-
 __submodules__ = [
+    '_version',
     'histogram',
     'features',
     'linalg',
@@ -37,6 +36,11 @@ __submodules__ = [
     'symbolic',
     'demodata',
 ]
+
+try:
+    from vtool._version import __version__
+except ImportError:
+    __version__ = '0.0.0'
 
 from vtool import histogram
 from vtool import features


### PR DESCRIPTION
This adjust the python distribution code to pull the version from git. It also writes the version to file, so that non-git distributions (e.g. wheels) of the code can access the version.

The code used to discover and write the version is localized to the python setup instructions, meaning that no extra steps outside of normal workflow procedures need to be done. This keeps things clean and clear even for someone not familiar with the project, but generally aware of the typical python package release process as documented by the PyPA (Python Package Authority).

The version that gets written to file is the version as it shows up in the git tag. This means that no direct code changes are done to include the version. The written version can be accessed by both the source distribution and wheel.

Also, both CMake and the python distribution setup code have been adjusted to get the version info from a single source of truth. They are essentially using the same code to drive the version in this case.

The last commit fixes the workflow's cache on macOS. It was only caching `/opt/opencv`, which doesn't contain MacPorts.